### PR TITLE
Bump version to 1.0.1 and update project metadata

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: Mainline
-next-version: 1.0.0
+next-version: 1.0.1
 branches:
   feature:
     tag: preview

--- a/settings.props
+++ b/settings.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Basic Settings">
-	<VersionPrefix>1.0.0</VersionPrefix>
+	<VersionPrefix>1.0.1</VersionPrefix>
 	<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 	<SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 	<NoWarn>$(NoWarn);CS1591;NU1605;DS126858;DS137138;SA1010;SA1011</NoWarn>

--- a/src/EasyKeys.Veeqo.Abstractions/EasyKeys.Veeqo.Abstractions.csproj
+++ b/src/EasyKeys.Veeqo.Abstractions/EasyKeys.Veeqo.Abstractions.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup Label="Nuget Package Settings">
     <Description>DotNetCore Abstractions of veeqo Library.</Description>
     <PackageTags>DotNetCore, veeqo Abstractions</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +25,13 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Polly.Extensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/EasyKeys.Veeqo.BulkTagging/EasyKeys.Veeqo.BulkTagging.csproj
+++ b/src/EasyKeys.Veeqo.BulkTagging/EasyKeys.Veeqo.BulkTagging.csproj
@@ -12,6 +12,7 @@
 	    <PackageTags>
 		    DotNetCore, Veeqo, Amazon
 	    </PackageTags>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyKeys.Veeqo.Abstractions\EasyKeys.Veeqo.Abstractions.csproj" />

--- a/src/EasyKeys.Veeqo.Orders/EasyKeys.Veeqo.Orders.csproj
+++ b/src/EasyKeys.Veeqo.Orders/EasyKeys.Veeqo.Orders.csproj
@@ -12,6 +12,7 @@
 	    <PackageTags>
 		    DotNetCore, Veeqo, Amazon
 	    </PackageTags>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/src/EasyKeys.Veeqo.Products/EasyKeys.Veeqo.Products.csproj
+++ b/src/EasyKeys.Veeqo.Products/EasyKeys.Veeqo.Products.csproj
@@ -12,6 +12,7 @@
 		<PackageTags>
 			DotNetCore, Veeqo, Amazon
 		</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/src/EasyKeys.Veeqo.StockEntries/EasyKeys.Veeqo.StockEntries.csproj
+++ b/src/EasyKeys.Veeqo.StockEntries/EasyKeys.Veeqo.StockEntries.csproj
@@ -12,6 +12,8 @@
 		<PackageTags>
 			DotNetCore, Veeqo, Amazon
 		</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+
 	</PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyKeys.Veeqo.Abstractions\EasyKeys.Veeqo.Abstractions.csproj" />


### PR DESCRIPTION
Updated GitVersion.yml and settings.props to change the version from 1.0.0 to 1.0.1. Added PackageReadmeFile entries in multiple .csproj files to include README.md in the NuGet package. Ensured README.md is packed with the NuGet package by including a new ItemGroup in EasyKeys.Veeqo.Abstractions.csproj.