### PR TITLE
Add AdditionalOptions to VeeqoLineItem; update tests

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 2.0.1
+next-version: 2.0.3
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/src/EasyKeys.Veeqo.Orders/Models/Response/VeeqoLineItem.cs
+++ b/src/EasyKeys.Veeqo.Orders/Models/Response/VeeqoLineItem.cs
@@ -15,4 +15,7 @@ public class VeeqoLineItem
 
     [JsonPropertyName("price_per_unit")]
     public decimal PricePerUnit { get; set; }
+
+    [JsonPropertyName("additional_options")]
+    public string AdditionalOptions { get; set; } = string.Empty;
 }

--- a/test/EasyKeys.Veeqo.IntegrationTests/Orders/VeeqoOrdersClientTests.cs
+++ b/test/EasyKeys.Veeqo.IntegrationTests/Orders/VeeqoOrdersClientTests.cs
@@ -138,7 +138,9 @@ public class VeeqoOrdersClientTests
     {
         var veeqoOrdersClient = sp.GetRequiredService<IVeeqoOrdersClient>();
 
-        var order = await veeqoOrdersClient.GetOrderAsync(1240276692);
+        var order = await veeqoOrdersClient.GetOrderAsync(1395192345);
+
+        Assert.NotNull(order);
     }
 
     [RunnableInDebugOnly]


### PR DESCRIPTION
Added AdditionalOptions property to VeeqoLineItem for JSON mapping. Updated GetOrderAsync test to use a new order ID. Bumped next-version in GitVersion.yml from 2.0.1 to 2.0.3.